### PR TITLE
Proofs

### DIFF
--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -25,6 +25,9 @@ instance
     = refl
 
   iLawfulMonoidList .concatenation [] = refl
-  iLawfulMonoidList .concatenation (x ∷ xs)
-    rewrite ++-[] x
-    = trustMe -- TODO
+  iLawfulMonoidList .concatenation ([] ∷ xs) = begin
+    mconcat xs              ≡⟨  concatenation xs  ⟩
+    foldr _<>_ [] (xs) ∎
+  iLawfulMonoidList .concatenation ((y ∷ ys) ∷ xs) = begin
+    (y ∷ ys) <> mconcat (xs)             ≡⟨ cong ( (y ∷ ys) <>_) (concatenation xs)⟩
+    (y ∷ ys) <> (foldr _<>_ [] xs) ∎

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -25,9 +25,7 @@ instance
     = refl
 
   iLawfulMonoidList .concatenation [] = refl
-  iLawfulMonoidList .concatenation ([] ∷ xs) = begin
-    mconcat xs              ≡⟨  concatenation xs  ⟩
-    foldr _<>_ [] (xs) ∎
-  iLawfulMonoidList .concatenation ((y ∷ ys) ∷ xs) = begin
-    (y ∷ ys) <> mconcat (xs)             ≡⟨ cong ( (y ∷ ys) <>_) (concatenation xs)⟩
-    (y ∷ ys) <> (foldr _<>_ [] xs) ∎
+  iLawfulMonoidList .concatenation (x ∷ xs) 
+    rewrite ++-[] (x ∷ xs)
+      | concatenation xs
+    = refl

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -29,3 +29,4 @@ instance
     rewrite ++-[] (x ∷ xs)
       | concatenation xs
     = refl
+    

--- a/lib/Haskell/Law/Monoid/List.agda
+++ b/lib/Haskell/Law/Monoid/List.agda
@@ -29,4 +29,3 @@ instance
     rewrite ++-[] (x ∷ xs)
       | concatenation xs
     = refl
-    

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -1,6 +1,7 @@
 module Haskell.Law.Monoid.Maybe where
 
 open import Haskell.Prim
+open import Haskell.Prim.Foldable
 open import Haskell.Prim.Maybe
 
 open import Haskell.Prim.Monoid
@@ -16,6 +17,11 @@ instance
 
   iLawfulMonoidMaybe .leftIdentity = λ { Nothing → refl; (Just _) → refl }
 
-  iLawfulMonoidMaybe .concatenation [] = refl
-  iLawfulMonoidMaybe .concatenation (x ∷ xs) = trustMe -- TODO
+  iLawfulMonoidMaybe .concatenation []              = refl
+  iLawfulMonoidMaybe .concatenation (Nothing ∷  xs) = begin
+    mconcat xs              ≡⟨  concatenation xs  ⟩
+    foldr _<>_ Nothing (xs) ∎
+  iLawfulMonoidMaybe .concatenation (Just x ∷ xs)   = begin
+    Just x <> mconcat (xs)             ≡⟨ cong ( Just x <>_) (concatenation xs)⟩
+    Just x <> (foldr _<>_ Nothing xs) ∎
 

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -17,11 +17,8 @@ instance
 
   iLawfulMonoidMaybe .leftIdentity = λ { Nothing → refl; (Just _) → refl }
 
-  iLawfulMonoidMaybe .concatenation []              = refl
-  iLawfulMonoidMaybe .concatenation (Nothing ∷  xs) = begin
-    mconcat xs              ≡⟨  concatenation xs  ⟩
-    foldr _<>_ Nothing (xs) ∎
-  iLawfulMonoidMaybe .concatenation (Just x ∷ xs)   = begin
-    Just x <> mconcat (xs)             ≡⟨ cong ( Just x <>_) (concatenation xs)⟩
-    Just x <> (foldr _<>_ Nothing xs) ∎
+  iLawfulMonoidMaybe .concatenation [] = refl
+  iLawfulMonoidMaybe .concatenation (x ∷  xs) 
+    rewrite (concatenation xs)
+    = refl
 

--- a/lib/Haskell/Law/Monoid/Maybe.agda
+++ b/lib/Haskell/Law/Monoid/Maybe.agda
@@ -18,7 +18,6 @@ instance
   iLawfulMonoidMaybe .leftIdentity = λ { Nothing → refl; (Just _) → refl }
 
   iLawfulMonoidMaybe .concatenation [] = refl
-  iLawfulMonoidMaybe .concatenation (x ∷  xs) 
+  iLawfulMonoidMaybe .concatenation (x ∷ xs) 
     rewrite (concatenation xs)
     = refl
-

--- a/lib/Haskell/Law/Ord/Def.agda
+++ b/lib/Haskell/Law/Ord/Def.agda
@@ -80,112 +80,74 @@ eq2ngt x y h
     | equality (compare x y) EQ h
   = refl
 
-lt2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
-  → ∀ (x y : a) → (x < y) ≡ True → (x <= y) ≡ True
-lt2lte x y h = &&-rightTrue' (x < y) (x <= y) (x /= y) (lt2LteNeq x y) h
-
-eqOrLeft : ∀ {x y a : Bool} → x ≡ y →  (x || a) ≡ (y || a)
-eqOrLeft {False} {False} f = refl
-eqOrLeft {True} {True} f = refl
-
-eqOrRight : ∀ {x y a : Bool} → x ≡ y →  (a || x) ≡ (a || y)
-eqOrRight {False} {False} f = refl
-eqOrRight {True} {True} f = refl
-
-eqA : ∀ { x y z : Ord} → x ≡ y → (x == z) → (y == z)
-eqA f g = ?
-
-gte2GtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
-  → ∀ (x y : a) → (x >= y) ≡ (x > y || x == y)
-gte2GtEq x y with (compare x y) in h₁
-gte2GtEq x y | LT = 
-  begin
-    (x >= y)
-  ≡˘⟨ {!   !} ⟩ 
-    ((LT == GT) || (x == y))
-  ≡˘⟨ {!   !} ⟩
-    ((compare x y == GT) || (x == y))
-  ≡˘⟨ (eqOrLeft (compareGt x y) ) ⟩
-    (x > y || x == y)
-  ∎
-gte2GtEq x y | EQ = {!   !}
-gte2GtEq x y | GT = {!   !}
--- gte2GtEq x y with (x > y) in h₁ 
--- gte2GtEq x y | True = 
---   begin
---     (x >= y)
---   ≡˘⟨ (lte2gte y x)⟩ 
---     (y <= x)
---   ≡⟨(lt2lte y x (trans (lt2gt y x) h₁) )⟩
---     True
---   ∎
--- gte2GtEq x y | False with (x == y) in h₂
--- gte2GtEq x y | False | True = 
---   begin
---     (x >= y)
---   ≡⟨ {!!} ⟩ 
---     {!!}
---   ≡⟨{!!}⟩
---     True
---   ∎
--- gte2GtEq x y | False | False = {!!}
-
-
-equationalNegation₁ : ∀ {x y : Bool } → x ≡ y → (not x) ≡ (not y)
-equationalNegation₁ {False} {False} h₁ = refl 
-equationalNegation₁ {True} {True} h₁ = refl  
-
-deMorgan1 : ∀ { x y : Bool } → not (x && y) ≡ ((not x) || (not y))
-deMorgan1 {False} {False} = refl
-deMorgan1 {False} {True} = refl  
-deMorgan1 {True} {False} = refl 
-deMorgan1 {True} {True} = refl
-
-gte2nlt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
-  → ∀ (x y : a) → (x >= y) ≡ not (x < y)
-gte2nlt x y = 
-  begin
-    (x >= y)
-  ≡⟨ {!!} ⟩ 
-   ((not (x <= y)) || (x == y))
-  ≡⟨ {!   !} ⟩ 
-    (not (x <= y) || not (x /= y))
-  ≡˘⟨ deMorgan1  {x <= y} {x /= y} ⟩ 
-    not (x <= y && x /= y)
-  ≡˘⟨ (equationalNegation₁ (lt2LteNeq x y)) ⟩
-    not (x < y)
-  ∎
-  -- rewrite gte2GtEq x y
-  --   | compareGt x y
-  --   | compareEq x y
-  --   | sym (compareLt x y)
-  -- = {!!} --trustMe -- TODO
-
-gte2nLT : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
-  → ∀ (x y : a) → (x >= y) ≡ (compare x y /= LT)
-gte2nLT x y
-  rewrite gte2nlt x y
-    | compareLt x y
-  = refl
-
 lte2LtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x <= y) ≡ (x < y || x == y)
-lte2LtEq x y = trustMe -- TODO
+lte2LtEq x y with (x <= y) in h₁ | (x < y) in h₂ | (x == y) in h₃
+... | False | False | False  = refl
+... | False | _     | True   = magic (exFalso (reflexivity x) (begin 
+    (x <= x)  ≡⟨ (cong (x <=_) (equality x y h₃) ) ⟩
+    (x <= y)  ≡⟨ h₁ ⟩ 
+    False     ∎))
+... | False | True  | _      = magic (exFalso h₂ (begin 
+    (x < y)             ≡⟨ (lt2LteNeq x y)⟩    
+    (x <= y && x /= y)  ≡⟨ (cong  (_&& (x /= y)) h₁ ) ⟩ 
+    (False && x /= y)   ∎ )) 
+... | True  | True  | _      = refl
+... | True  | b     | True   = begin 
+    True        ≡˘⟨ (||-rightTrue b True refl ) ⟩    
+    (b || True) ∎ 
+... | True | False  | False  = magic (exFalso (begin 
+    (x < y)                 ≡⟨ (lt2LteNeq x y) ⟩
+    (x <= y && x /= y)      ≡⟨ (cong₂  _&&_  h₁ refl ) ⟩ 
+    (True && not (x == y))  ≡⟨ (cong (λ { x → True && not x }) h₃ )⟩
+    (True && not False)     ≡⟨ (&&-semantics True (not False) refl refl) ⟩
+    True
+  ∎ ) h₂ )
 
 lte2ngt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x <= y) ≡ not (x > y)
-lte2ngt x y
+lte2ngt x y 
   rewrite lte2LtEq x y
     | compareLt x y
     | compareEq x y
-    | sym (compareGt x y)
-  = trustMe -- TODO
+    | compareGt x y
+  with compare x y
+... | GT = refl 
+... | EQ = refl 
+... | LT = refl 
 
 lte2nGT : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x <= y) ≡ (compare x y /= GT)
 lte2nGT x y
   rewrite lte2ngt x y
     | compareGt x y
+  = refl
+
+gte2GtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
+  → ∀ (x y : a) → (x >= y) ≡ (x > y || x == y)
+gte2GtEq x y = begin
+  (x >= y)          ≡˘⟨ (lte2gte y x) ⟩
+  (y <= x)          ≡⟨ (lte2LtEq y x) ⟩
+  (y < x || y == x) ≡⟨ (cong₂ _||_ (lt2gt y x) (eqSymmetry y x)) ⟩
+  (x > y || x == y) ∎   
+
+gte2nlt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
+  → ∀ (x y : a) → (x >= y) ≡ not (x < y)
+gte2nlt x y 
+  rewrite gte2GtEq x y
+    | compareLt x y
+    | compareEq x y
+    | compareGt x y
+  with compare x y
+... | GT = refl 
+... | EQ = refl 
+... | LT = refl 
+
+gte2nLT : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
+  → ∀ (x y : a) → (x >= y) ≡ (compare x y /= LT)
+gte2nLT x y
+  rewrite gte2nlt x y
+    | compareLt x y
   = refl
 
 eq2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
@@ -202,6 +164,10 @@ eq2gte x y h
     | eq2nlt x y h
   = refl
 
+lt2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
+  → ∀ (x y : a) → (x < y) ≡ True → (x <= y) ≡ True
+lt2lte x y h = &&-rightTrue' (x < y) (x <= y) (x /= y) (lt2LteNeq x y) h
+
 gt2gte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x > y) ≡ True → (x >= y) ≡ True
 gt2gte x y h
@@ -209,6 +175,7 @@ gt2gte x y h
     | sym (lt2lte y x h)
     | lte2gte y x
   = refl
+
 
 --------------------------------------------------
 -- Postulated instances
@@ -233,4 +200,4 @@ postulate instance
   iLawfulOrdList : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄ → IsLawfulOrd (List a)
 
   iLawfulOrdEither : ⦃ iOrdA : Ord a ⦄ → ⦃ iOrdB : Ord b ⦄ →  ⦃ IsLawfulOrd a ⦄ → ⦃ IsLawfulOrd b ⦄ → IsLawfulOrd (Either a b)
- 
+   

--- a/lib/Haskell/Law/Ord/Def.agda
+++ b/lib/Haskell/Law/Ord/Def.agda
@@ -82,27 +82,22 @@ eq2ngt x y h
 
 lte2LtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x <= y) ≡ (x < y || x == y)
-lte2LtEq x y with (x <= y) in h₁ | (x < y) in h₂ | (x == y) in h₃
-... | False | False | False  = refl
-... | False | _     | True   = magic (exFalso (reflexivity x) (begin 
-    (x <= x)  ≡⟨ (cong (x <=_) (equality x y h₃) ) ⟩
+lte2LtEq x y 
+  rewrite lt2LteNeq x y
+    | compareEq x y
+  with (x <= y) in h₁ | (compare x y) in h₂
+... | False | LT = refl
+... | False | EQ = magic $ exFalso (reflexivity x) $ begin 
+    (x <= x)  ≡⟨ (cong (x <=_) (equality x y (begin 
+      (x == y)            ≡⟨ compareEq x y ⟩ 
+      (compare x y == EQ) ≡⟨ equality' (compare x y) EQ h₂ ⟩ 
+      True                ∎ ) ) ) ⟩
     (x <= y)  ≡⟨ h₁ ⟩ 
-    False     ∎))
-... | False | True  | _      = magic (exFalso h₂ (begin 
-    (x < y)             ≡⟨ (lt2LteNeq x y)⟩    
-    (x <= y && x /= y)  ≡⟨ (cong  (_&& (x /= y)) h₁ ) ⟩ 
-    (False && x /= y)   ∎ )) 
-... | True  | True  | _      = refl
-... | True  | b     | True   = begin 
-    True        ≡˘⟨ (||-rightTrue b True refl ) ⟩    
-    (b || True) ∎ 
-... | True | False  | False  = magic (exFalso (begin 
-    (x < y)                 ≡⟨ (lt2LteNeq x y) ⟩
-    (x <= y && x /= y)      ≡⟨ (cong₂  _&&_  h₁ refl ) ⟩ 
-    (True && not (x == y))  ≡⟨ (cong (λ { x → True && not x }) h₃ )⟩
-    (True && not False)     ≡⟨ (&&-semantics True (not False) refl refl) ⟩
-    True
-  ∎ ) h₂ )
+    False ∎
+... | False | GT = refl
+... | True  | LT = refl
+... | True  | EQ = refl
+... | True  | GT = refl
 
 lte2ngt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x <= y) ≡ not (x > y)
@@ -200,4 +195,4 @@ postulate instance
   iLawfulOrdList : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄ → IsLawfulOrd (List a)
 
   iLawfulOrdEither : ⦃ iOrdA : Ord a ⦄ → ⦃ iOrdB : Ord b ⦄ →  ⦃ IsLawfulOrd a ⦄ → ⦃ IsLawfulOrd b ⦄ → IsLawfulOrd (Either a b)
-   
+    

--- a/lib/Haskell/Law/Ord/Def.agda
+++ b/lib/Haskell/Law/Ord/Def.agda
@@ -84,38 +84,82 @@ lt2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x < y) ≡ True → (x <= y) ≡ True
 lt2lte x y h = &&-rightTrue' (x < y) (x <= y) (x /= y) (lt2LteNeq x y) h
 
+eqOrLeft : ∀ {x y a : Bool} → x ≡ y →  (x || a) ≡ (y || a)
+eqOrLeft {False} {False} f = refl
+eqOrLeft {True} {True} f = refl
+
+eqOrRight : ∀ {x y a : Bool} → x ≡ y →  (a || x) ≡ (a || y)
+eqOrRight {False} {False} f = refl
+eqOrRight {True} {True} f = refl
+
+eqA : ∀ { x y z : Ord} → x ≡ y → (x == z) → (y == z)
+eqA f g = ?
+
 gte2GtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ (x > y || x == y)
-gte2GtEq x y with (x > y) in h₁ 
-gte2GtEq x y | True = 
+gte2GtEq x y with (compare x y) in h₁
+gte2GtEq x y | LT = 
   begin
     (x >= y)
-  ≡˘⟨ (lte2gte y x)⟩ 
-    (y <= x)
-  ≡⟨(lt2lte y x (trans (lt2gt y x) h₁) )⟩
-    True
+  ≡˘⟨ {!   !} ⟩ 
+    ((LT == GT) || (x == y))
+  ≡˘⟨ {!   !} ⟩
+    ((compare x y == GT) || (x == y))
+  ≡˘⟨ (eqOrLeft (compareGt x y) ) ⟩
+    (x > y || x == y)
   ∎
-gte2GtEq x y | False with (x == y) in h₂
-gte2GtEq x y | False | True = 
-  begin
-    (x >= y)
-  ≡⟨ {!!} ⟩ 
-    {!!}
-  ≡⟨{!!}⟩
-    True
-  ∎
-gte2GtEq x y | False | False = {!!}
+gte2GtEq x y | EQ = {!   !}
+gte2GtEq x y | GT = {!   !}
+-- gte2GtEq x y with (x > y) in h₁ 
+-- gte2GtEq x y | True = 
+--   begin
+--     (x >= y)
+--   ≡˘⟨ (lte2gte y x)⟩ 
+--     (y <= x)
+--   ≡⟨(lt2lte y x (trans (lt2gt y x) h₁) )⟩
+--     True
+--   ∎
+-- gte2GtEq x y | False with (x == y) in h₂
+-- gte2GtEq x y | False | True = 
+--   begin
+--     (x >= y)
+--   ≡⟨ {!!} ⟩ 
+--     {!!}
+--   ≡⟨{!!}⟩
+--     True
+--   ∎
+-- gte2GtEq x y | False | False = {!!}
 
 
+equationalNegation₁ : ∀ {x y : Bool } → x ≡ y → (not x) ≡ (not y)
+equationalNegation₁ {False} {False} h₁ = refl 
+equationalNegation₁ {True} {True} h₁ = refl  
+
+deMorgan1 : ∀ { x y : Bool } → not (x && y) ≡ ((not x) || (not y))
+deMorgan1 {False} {False} = refl
+deMorgan1 {False} {True} = refl  
+deMorgan1 {True} {False} = refl 
+deMorgan1 {True} {True} = refl
 
 gte2nlt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ not (x < y)
-gte2nlt x y
-  rewrite gte2GtEq x y
-    | compareGt x y
-    | compareEq x y
-    | sym (compareLt x y)
-  = {!!} --trustMe -- TODO
+gte2nlt x y = 
+  begin
+    (x >= y)
+  ≡⟨ {!!} ⟩ 
+   ((not (x <= y)) || (x == y))
+  ≡⟨ {!   !} ⟩ 
+    (not (x <= y) || not (x /= y))
+  ≡˘⟨ deMorgan1  {x <= y} {x /= y} ⟩ 
+    not (x <= y && x /= y)
+  ≡˘⟨ (equationalNegation₁ (lt2LteNeq x y)) ⟩
+    not (x < y)
+  ∎
+  -- rewrite gte2GtEq x y
+  --   | compareGt x y
+  --   | compareEq x y
+  --   | sym (compareLt x y)
+  -- = {!!} --trustMe -- TODO
 
 gte2nLT : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ (compare x y /= LT)
@@ -189,3 +233,4 @@ postulate instance
   iLawfulOrdList : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄ → IsLawfulOrd (List a)
 
   iLawfulOrdEither : ⦃ iOrdA : Ord a ⦄ → ⦃ iOrdB : Ord b ⦄ →  ⦃ IsLawfulOrd a ⦄ → ⦃ IsLawfulOrd b ⦄ → IsLawfulOrd (Either a b)
+ 

--- a/lib/Haskell/Law/Ord/Def.agda
+++ b/lib/Haskell/Law/Ord/Def.agda
@@ -80,9 +80,33 @@ eq2ngt x y h
     | equality (compare x y) EQ h
   = refl
 
+lt2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
+  → ∀ (x y : a) → (x < y) ≡ True → (x <= y) ≡ True
+lt2lte x y h = &&-rightTrue' (x < y) (x <= y) (x /= y) (lt2LteNeq x y) h
+
 gte2GtEq : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ (x > y || x == y)
-gte2GtEq x y = trustMe -- TODO
+gte2GtEq x y with (x > y) in h₁ 
+gte2GtEq x y | True = 
+  begin
+    (x >= y)
+  ≡˘⟨ (lte2gte y x)⟩ 
+    (y <= x)
+  ≡⟨(lt2lte y x (trans (lt2gt y x) h₁) )⟩
+    True
+  ∎
+gte2GtEq x y | False with (x == y) in h₂
+gte2GtEq x y | False | True = 
+  begin
+    (x >= y)
+  ≡⟨ {!!} ⟩ 
+    {!!}
+  ≡⟨{!!}⟩
+    True
+  ∎
+gte2GtEq x y | False | False = {!!}
+
+
 
 gte2nlt : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ not (x < y)
@@ -91,7 +115,7 @@ gte2nlt x y
     | compareGt x y
     | compareEq x y
     | sym (compareLt x y)
-  = trustMe -- TODO
+  = {!!} --trustMe -- TODO
 
 gte2nLT : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x >= y) ≡ (compare x y /= LT)
@@ -126,10 +150,6 @@ eq2lte x y h
   rewrite lte2ngt x y
     | eq2ngt x y h
   = refl
-
-lt2lte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
-  → ∀ (x y : a) → (x < y) ≡ True → (x <= y) ≡ True
-lt2lte x y h = &&-rightTrue' (x < y) (x <= y) (x /= y) (lt2LteNeq x y) h
 
 eq2gte : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄
   → ∀ (x y : a) → (x == y) ≡ True → (x >= y) ≡ True

--- a/lib/Haskell/Law/Ord/Def.agda
+++ b/lib/Haskell/Law/Ord/Def.agda
@@ -195,4 +195,3 @@ postulate instance
   iLawfulOrdList : ⦃ iOrdA : Ord a ⦄ → ⦃ IsLawfulOrd a ⦄ → IsLawfulOrd (List a)
 
   iLawfulOrdEither : ⦃ iOrdA : Ord a ⦄ → ⦃ iOrdB : Ord b ⦄ →  ⦃ IsLawfulOrd a ⦄ → ⦃ IsLawfulOrd b ⦄ → IsLawfulOrd (Either a b)
-    

--- a/lib/Haskell/Prim.agda
+++ b/lib/Haskell/Prim.agda
@@ -95,6 +95,11 @@ data ⊥ : Set where
 magic : {A : Set} → ⊥ → A
 magic ()
 
+--principle of explosion
+exFalso : {x : Bool} → (x ≡ True) → (x ≡ False) → ⊥
+exFalso {False} () b 
+exFalso {True} a ()
+
 -- Use to bundle up constraints
 data All {a b} {A : Set a} (B : A → Set b) : List A → Set (a ⊔ b) where
   instance


### PR DESCRIPTION
Proofs completed:
 - Lawful ordering: `gte2GtEq`, `lte2LtEq', 'gte2nlt', 'lte2ngt'
 - Lawful Monoid: composition instance for `List` and `Maybe`
- added principle of explosion (`exFalso`) in `lib/Haskell/Prim` (not sure if the right file to put it)